### PR TITLE
chore: reuse or pin local Actions + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -8,19 +8,10 @@ on:
       - ".github/workflows/yaml-lint.yml"
   workflow_call:
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
-  lint:
-    name: Lint YAML files
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run yamllint
-        uses: karancode/yamllint-github-action@v2.1.0
-        with:
-          yamllint_file_or_dir: .
-          yamllint_config_filepath: .yamllint
-          yamllint_format: github
-          yamllint_strict: false
+  yaml-lint:
+    uses: actionsforge/actions/.github/workflows/yaml-lint.yml@main


### PR DESCRIPTION
## Summary
- Convert chart `yaml-lint.yml` workflows that used floating `karancode/yamllint-github-action` to `actionsforge` `yaml-lint` reusable
- SHA-pin remaining floating marketplace actions (e.g. kube-platform-apps validators)
- Keep pip-based yaml-lint where karancode is intentionally avoided
- Add Dependabot for `github-actions` when missing

## Test plan
- [ ] Required workflow checks pass